### PR TITLE
Add Caixas e Bancos submenu

### DIFF
--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -19,6 +19,9 @@ function Sidebar() {
                 <NavItem>
                     <StyledNavLink to="/lancamentos">Lançamentos</StyledNavLink>
                 </NavItem>
+                <NavItem>
+                    <StyledNavLink to="/caixas-bancos">Caixas e Bancos</StyledNavLink>
+                </NavItem>
             </NavList>
         </SidebarContainer>
     );

--- a/src/pages/caixas-bancos/index.tsx
+++ b/src/pages/caixas-bancos/index.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from "react";
+import {
+  Container,
+  Breadcrumb,
+  Header,
+  Selector,
+  SearchInput,
+  Tabs,
+  Tab,
+  TableWrapper,
+  Actions,
+  SidePanel,
+  ButtonGreen,
+  Summary
+} from "./style";
+
+const CaixasEBancos: React.FC = () => {
+  const [tab, setTab] = useState<string>("movimentacoes");
+
+  return (
+    <Container>
+      <div style={{ flex: 1 }}>
+        <Header>
+          <Breadcrumb>... &gt; Caixas e Bancos</Breadcrumb>
+          <Selector defaultValue="all">
+            <option value="all">Todas contas ⏷</option>
+            <option value="1">Conta 1</option>
+            <option value="2">Conta 2</option>
+          </Selector>
+        </Header>
+        <SearchInput placeholder="Pesquise por nome ou histórico" />
+        <Tabs>
+          <Tab
+            onClick={() => setTab("movimentacoes")}
+            data-active={tab === "movimentacoes"}
+          >
+            Movimentações
+          </Tab>
+          <Tab onClick={() => setTab("entradas")} data-active={tab === "entradas"}>
+            Entradas
+          </Tab>
+          <Tab onClick={() => setTab("saidas")} data-active={tab === "saidas"}>
+            Saídas
+          </Tab>
+        </Tabs>
+        <Actions>
+          <button>Imprimir saldos</button>
+          <button>Exportar extrato</button>
+        </Actions>
+        <TableWrapper>
+          <table>
+            <thead>
+              <tr>
+                <th></th>
+                <th>Data</th>
+                <th>Categoria</th>
+                <th>Histórico</th>
+                <th>Cliente/Fornecedor</th>
+                <th>Conta</th>
+                <th>Valor</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <input type="checkbox" />
+                </td>
+                <td>01/06/2025</td>
+                <td></td>
+                <td>Ref. ao pedido de venda nº 12345 | Método de pagamento: PIX</td>
+                <td>Fulano LTDA</td>
+                <td>02 - Mercado Livre (Ebazarr)</td>
+                <td style={{ color: "green" }}>V 100,00</td>
+              </tr>
+            </tbody>
+          </table>
+        </TableWrapper>
+      </div>
+      <SidePanel>
+        <ButtonGreen>Incluir lançamento</ButtonGreen>
+        <ButtonGreen>Transferência entre contas</ButtonGreen>
+        <Summary>
+          <p>Quantidade de registros: 1</p>
+          <p>Saldo atual da conta: R$ 100,00</p>
+          <p>Entradas: R$ 100,00</p>
+          <p>Saídas: R$ 0,00</p>
+        </Summary>
+      </SidePanel>
+    </Container>
+  );
+};
+
+export default CaixasEBancos;

--- a/src/pages/caixas-bancos/style.tsx
+++ b/src/pages/caixas-bancos/style.tsx
@@ -1,0 +1,87 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  gap: 20px;
+  width: 100%;
+`;
+
+export const Header = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+`;
+
+export const Breadcrumb = styled.span`
+  font-weight: bold;
+`;
+
+export const Selector = styled.select`
+  padding: 5px;
+  background-color: #2ecc71;
+  color: white;
+  border: none;
+  border-radius: 4px;
+`;
+
+export const SearchInput = styled.input`
+  width: 100%;
+  padding: 5px;
+  margin-bottom: 10px;
+`;
+
+export const Tabs = styled.div`
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+`;
+
+export const Tab = styled.button<{ 'data-active'?: boolean }>`
+  padding: 5px 10px;
+  background-color: ${(props) => (props['data-active'] ? '#3498db' : '#ecf0f1')};
+  color: ${(props) => (props['data-active'] ? 'white' : 'black')};
+  border: none;
+  border-radius: 4px;
+`;
+
+export const Actions = styled.div`
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-bottom: 10px;
+`;
+
+export const TableWrapper = styled.div`
+  overflow-x: auto;
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  th, td {
+    border: 1px solid #ccc;
+    padding: 8px;
+    text-align: left;
+  }
+`;
+
+export const SidePanel = styled.aside`
+  width: 250px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+export const ButtonGreen = styled.button`
+  background-color: #2ecc71;
+  color: white;
+  border: none;
+  padding: 10px;
+  border-radius: 4px;
+`;
+
+export const Summary = styled.div`
+  background-color: #f4f4f9;
+  padding: 10px;
+  border-radius: 4px;
+`;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route } from 'react-router-dom';
 import Layout from '../components/layout';
 import Lacamentos from '../pages/lancamentos';
+import CaixasEBancos from '../pages/caixas-bancos';
 import Login from '../pages/login';
 
 function App() {
@@ -15,6 +16,7 @@ function App() {
                 <Route path="/about" element={<div>about</div>} />
                 <Route path="/contact" element={<div>contact</div>} />
                 <Route path="/lancamentos" element={<Lacamentos />} />
+                <Route path="/caixas-bancos" element={<CaixasEBancos />} />
             </Route>
 
 


### PR DESCRIPTION
## Summary
- add Caixas e Bancos page with filters, tabs, table and side panel
- hook the new page into the router
- show Caixas e Bancos link in sidebar

## Testing
- `npm run lint` *(fails: `npm` not found)*
- `npm run build` *(not run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6846fbdb1e10832fa8b621d595a89397