### PR TITLE
Improve transfer and launch forms layout

### DIFF
--- a/src/pages/caixas-bancos/index.tsx
+++ b/src/pages/caixas-bancos/index.tsx
@@ -295,9 +295,10 @@ const CaixasEBancos: React.FC = () => {
         >
           <span>Insira as informações da transferência</span>
           <FieldRow>
-            <FieldWrapper>
+            <FieldWrapper style={{ width: "240px" }}>
               <FieldLabel>Conta origem</FieldLabel>
               <SelectInput
+                style={{ height: "40px" }}
                 value={originAccount}
                 onChange={(e) => setOriginAccount(e.target.value)}
               >
@@ -313,9 +314,10 @@ const CaixasEBancos: React.FC = () => {
               <BalanceInfo>Saldo: R$ {getBalance(originAccount)}</BalanceInfo>
             </FieldWrapper>
             <Arrow>→</Arrow>
-            <FieldWrapper>
+            <FieldWrapper style={{ width: "240px" }}>
               <FieldLabel>Conta destino</FieldLabel>
               <SelectInput
+                style={{ height: "40px" }}
                 value={destinationAccount}
                 onChange={(e) => setDestinationAccount(e.target.value)}
               >
@@ -334,17 +336,19 @@ const CaixasEBancos: React.FC = () => {
             </FieldWrapper>
           </FieldRow>
           <FieldRow>
-            <FieldWrapper>
+            <FieldWrapper style={{ width: "240px" }}>
               <FieldLabel>Valor R$</FieldLabel>
               <TextInput
+                style={{ height: "40px" }}
                 type="number"
                 value={transferValue}
                 onChange={(e) => setTransferValue(e.target.value)}
               />
             </FieldWrapper>
-            <FieldWrapper>
+            <FieldWrapper style={{ width: "240px" }}>
               <FieldLabel>Data da transferência</FieldLabel>
               <TextInput
+                style={{ height: "40px" }}
                 type="date"
                 value={transferDate}
                 onChange={(e) => setTransferDate(e.target.value)}

--- a/src/pages/caixas-bancos/style.tsx
+++ b/src/pages/caixas-bancos/style.tsx
@@ -143,6 +143,7 @@ export const FieldRow = styled.div`
   display: flex;
   flex-direction: row;
   gap: 10px;
+  align-items: center;
 `;
 
 export const FieldWrapper = styled.div`
@@ -182,7 +183,7 @@ export const PanelActions = styled.div`
   justify-content: flex-end;
   gap: 10px;
   margin-top: auto;
-  margin-bottom: 20px;
+  margin-bottom: 40px;
 `;
 
 export const BalanceInfo = styled.span`
@@ -192,5 +193,5 @@ export const BalanceInfo = styled.span`
 
 export const Arrow = styled.span`
   font-size: 20px;
-  align-self: flex-end;
+  align-self: center;
 `;


### PR DESCRIPTION
## Summary
- vertically align arrow between account selectors
- space action buttons from the bottom of the panel
- enlarge transfer form fields for better spacing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684753286764832fab4260248b55157f