### PR TITLE
Add themed buttons for lancamentos

### DIFF
--- a/src/pages/lancamentos/index.tsx
+++ b/src/pages/lancamentos/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Container, Description, Div1, Div2 } from "./style";
+import { Container, Description, Div1, Div2, LaunchButton } from "./style";
 
 
 const Lacamentos: React.FC = () => {
@@ -15,7 +15,7 @@ const Lacamentos: React.FC = () => {
                 <Description value={text} onChange={(event) => setText(event?.target.value)} />
             </Div1>
             <Div2>
-
+                <LaunchButton>Exemplo</LaunchButton>
             </Div2>
         </Container>
     )

--- a/src/pages/lancamentos/style.tsx
+++ b/src/pages/lancamentos/style.tsx
@@ -29,7 +29,20 @@ export const Div2 = styled.div`
     @media screen  {
         
     }
-`
+`;
+
+export const LaunchButton = styled.button`
+    background-color: ${({ theme }) => theme.button.background};
+    color: ${({ theme }) => theme.button.color};
+    border: ${({ theme }) => theme.button.border};
+    border-radius: ${({ theme }) => theme.button.borderRadius};
+    padding: ${({ theme }) => theme.button.padding};
+    cursor: pointer;
+
+    &:hover {
+        opacity: 0.9;
+    }
+`;
 
 export const Description = styled.input`
     padding: 5px;

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -9,6 +9,13 @@ export const lightTheme = {
     secondary: "#993030",
     title: "",
   },
+  button: {
+    background: "#7B1E1E",
+    color: "#ffffff",
+    border: "none",
+    borderRadius: "8px",
+    padding: "10px",
+  },
 };
 
 export const darkTheme = {
@@ -16,6 +23,13 @@ export const darkTheme = {
     background: "#121212",
     text: "#ffffff",
     primary: "#9b59b6",
+  },
+  button: {
+    background: "#9b59b6",
+    color: "#ffffff",
+    border: "none",
+    borderRadius: "8px",
+    padding: "10px",
   },
 };
 

--- a/styled.d.ts
+++ b/styled.d.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-empty-interface */
+/* eslint-disable @typescript-eslint/no-empty-object-type */
 
 import "styled-components";
 import { ThemeType } from "./src/theme";


### PR DESCRIPTION
## Summary
- define shared button style in theme
- expose LaunchButton styled component for `lancamentos`
- render a sample button on the page
- silence lint warning on `styled.d.ts`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685098d7fbec832fa7388de1ff80bb25