### PR TITLE
Add collapsible info sidebar

### DIFF
--- a/src/pages/caixas-bancos/index.tsx
+++ b/src/pages/caixas-bancos/index.tsx
@@ -12,6 +12,7 @@ import {
   Actions,
   IconButton,
   SidePanel,
+  ToggleButton,
   ButtonGreen,
   Summary,
   SummaryItem,
@@ -32,6 +33,7 @@ const CaixasEBancos: React.FC = () => {
   const [tab, setTab] = useState<string>("movimentacoes");
   const [showLaunch, setShowLaunch] = useState(false);
   const [showTransfer, setShowTransfer] = useState(false);
+  const [showInfo, setShowInfo] = useState(true);
   const [category, setCategory] = useState("");
   const [date, setDate] = useState("");
   const [value, setValue] = useState("");
@@ -423,31 +425,38 @@ const CaixasEBancos: React.FC = () => {
           </table>
         </TableWrapper>
       </div>
-      <SidePanel>
-        <Summary>
-          <SummaryItem>
-            Quantidade de registros:
-            <strong>4</strong>
-          </SummaryItem>
-          <SummaryItem>
-            Saldo atual da conta:
-            <strong>R$ 100,00</strong>
-          </SummaryItem>
-          <SummaryItem style={{ color: "green" }}>
-            Entradas:
-            <strong>R$ 180,00</strong>
-          </SummaryItem>
-          <SummaryItem style={{ color: "red" }}>
-            Saídas:
-            <strong>R$ 80,00</strong>
-          </SummaryItem>
-          <div style={{ marginTop: "10px" }}>
-            <strong>Saldos</strong>
-          </div>
-          <div>Conta 1 - R$ 70,00</div>
-          <div>Conta 2 - R$ 30,00</div>
-        </Summary>
-      </SidePanel>
+      {showInfo ? (
+        <SidePanel>
+          <ToggleButton onClick={() => setShowInfo(false)}>
+            Fechar
+          </ToggleButton>
+          <Summary>
+            <SummaryItem>
+              Quantidade de registros:
+              <strong>4</strong>
+            </SummaryItem>
+            <SummaryItem>
+              Saldo atual da conta:
+              <strong>R$ 100,00</strong>
+            </SummaryItem>
+            <SummaryItem style={{ color: "green" }}>
+              Entradas:
+              <strong>R$ 180,00</strong>
+            </SummaryItem>
+            <SummaryItem style={{ color: "red" }}>
+              Saídas:
+              <strong>R$ 80,00</strong>
+            </SummaryItem>
+            <div style={{ marginTop: "10px" }}>
+              <strong>Saldos</strong>
+            </div>
+            <div>Conta 1 - R$ 70,00</div>
+            <div>Conta 2 - R$ 30,00</div>
+          </Summary>
+        </SidePanel>
+      ) : (
+        <ToggleButton onClick={() => setShowInfo(true)}>Abrir painel</ToggleButton>
+      )}
       <SlidePanel open={showLaunch}>
         <button onClick={() => setShowLaunch(false)}>Fechar</button>
         <h3>Lançamento de caixa</h3>

--- a/src/pages/caixas-bancos/style.tsx
+++ b/src/pages/caixas-bancos/style.tsx
@@ -105,6 +105,15 @@ export const SidePanel = styled.aside`
   border: 1px solid rgba(0, 0, 0, 0.1);
 `;
 
+export const ToggleButton = styled.button`
+  background-color: ${({ theme }) => theme.button.background};
+  color: ${({ theme }) => theme.button.color};
+  border: ${({ theme }) => theme.button.border};
+  padding: ${({ theme }) => theme.button.padding};
+  border-radius: ${({ theme }) => theme.button.borderRadius};
+  cursor: pointer;
+`;
+
 export const ButtonGreen = styled.button`
   background-color: ${({ theme }) => theme.button.background};
   color: ${({ theme }) => theme.button.color};


### PR DESCRIPTION
## Summary
- add `ToggleButton` styled component
- allow side panel on lançamentos page to open/close

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850a0a1a32c832fa9e044f935695b9f