### PR TITLE
Improve sidebar icon logic and theming

### DIFF
--- a/src/components/sidebar/style.tsx
+++ b/src/components/sidebar/style.tsx
@@ -3,8 +3,8 @@ import { NavLink } from 'react-router-dom';
 
 export const SidebarContainer = styled.aside`
   width: 250px;
-  background-color: #2c3e50;
-  color: white;
+  background-color: ${({ theme }) => theme.colors.primary};
+  color: ${({ theme }) => theme.colors.text};
   padding: 20px;
   display: flex;
   flex-direction: column;
@@ -23,7 +23,7 @@ export const NavItem = styled.li`
 `;
 
 export const StyledNavLink = styled(NavLink)`
-  color: #ecf0f1;
+  color: ${({ theme }) => theme.colors.text};
   text-decoration: none;
   font-size: 1.1rem;
   padding: 10px;
@@ -31,11 +31,12 @@ export const StyledNavLink = styled(NavLink)`
   border-radius: 4px;
 
   &.active {
-    background-color: #3498db;
-    color: white;
+    background-color: ${({ theme }) => theme.button.background};
+    color: ${({ theme }) => theme.button.color};
+    border: ${({ theme }) => theme.button.border};
   }
 
   &:hover {
-    background-color: #34495e;
+    background-color: ${({ theme }) => theme.colors.secondary};
   }
 `;

--- a/src/pages/caixas-bancos/index.tsx
+++ b/src/pages/caixas-bancos/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { FaPrint, FaFileExport, FaPlus, FaExchangeAlt } from "react-icons/fa";
+import { FaPrint, FaFileExport, FaPlus, FaExchangeAlt, FaChevronLeft, FaChevronRight } from "react-icons/fa";
 import {
   Container,
   Breadcrumb,
@@ -428,7 +428,7 @@ const CaixasEBancos: React.FC = () => {
       {showInfo ? (
         <SidePanel>
           <ToggleButton onClick={() => setShowInfo(false)}>
-            Fechar
+            <FaChevronRight />
           </ToggleButton>
           <Summary>
             <SummaryItem>
@@ -455,7 +455,9 @@ const CaixasEBancos: React.FC = () => {
           </Summary>
         </SidePanel>
       ) : (
-        <ToggleButton onClick={() => setShowInfo(true)}>Abrir painel</ToggleButton>
+        <ToggleButton collapsed onClick={() => setShowInfo(true)}>
+          <FaChevronLeft />
+        </ToggleButton>
       )}
       <SlidePanel open={showLaunch}>
         <button onClick={() => setShowLaunch(false)}>Fechar</button>

--- a/src/pages/caixas-bancos/style.tsx
+++ b/src/pages/caixas-bancos/style.tsx
@@ -105,13 +105,24 @@ export const SidePanel = styled.aside`
   border: 1px solid rgba(0, 0, 0, 0.1);
 `;
 
-export const ToggleButton = styled.button`
+export const ToggleButton = styled.button<{ collapsed?: boolean }>`
   background-color: ${({ theme }) => theme.button.background};
   color: ${({ theme }) => theme.button.color};
   border: ${({ theme }) => theme.button.border};
-  padding: ${({ theme }) => theme.button.padding};
-  border-radius: ${({ theme }) => theme.button.borderRadius};
+  padding: ${({ collapsed, theme }) =>
+    collapsed ? "0" : theme.button.padding};
+  border-radius: ${({ collapsed, theme }) =>
+    collapsed ? "8px 0 0 8px" : theme.button.borderRadius};
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  ${({ collapsed }) =>
+    collapsed &&
+    `
+    width: 24px;
+    height: 60px;
+  `}
 `;
 
 export const ButtonGreen = styled.button`


### PR DESCRIPTION
## Summary
- correct chevron orientation for the right panel toggle
- theme sidebar menu items and highlight the active link

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850a2a55114832faa6f6b9c290b4635