### PR TITLE
Fix sidebar icons and revert theme

### DIFF
--- a/src/components/sidebar/style.tsx
+++ b/src/components/sidebar/style.tsx
@@ -3,8 +3,8 @@ import { NavLink } from 'react-router-dom';
 
 export const SidebarContainer = styled.aside`
   width: 250px;
-  background-color: ${({ theme }) => theme.colors.primary};
-  color: ${({ theme }) => theme.colors.text};
+  background-color: #2c3e50;
+  color: white;
   padding: 20px;
   display: flex;
   flex-direction: column;
@@ -23,7 +23,7 @@ export const NavItem = styled.li`
 `;
 
 export const StyledNavLink = styled(NavLink)`
-  color: ${({ theme }) => theme.colors.text};
+  color: #ecf0f1;
   text-decoration: none;
   font-size: 1.1rem;
   padding: 10px;
@@ -31,12 +31,11 @@ export const StyledNavLink = styled(NavLink)`
   border-radius: 4px;
 
   &.active {
-    background-color: ${({ theme }) => theme.button.background};
-    color: ${({ theme }) => theme.button.color};
-    border: ${({ theme }) => theme.button.border};
+    background-color: #3498db;
+    color: white;
   }
 
   &:hover {
-    background-color: ${({ theme }) => theme.colors.secondary};
+    background-color: #34495e;
   }
 `;

--- a/src/pages/caixas-bancos/index.tsx
+++ b/src/pages/caixas-bancos/index.tsx
@@ -429,8 +429,6 @@ const CaixasEBancos: React.FC = () => {
         <SidePanel>
           <ToggleButton onClick={() => setShowInfo(false)}>
             <FaChevronRight />
-
-            <FaChevronLeft />
           </ToggleButton>
           <Summary>
             <SummaryItem>
@@ -459,8 +457,6 @@ const CaixasEBancos: React.FC = () => {
       ) : (
         <ToggleButton collapsed onClick={() => setShowInfo(true)}>
           <FaChevronLeft />
-
-          <FaChevronRight />
         </ToggleButton>
       )}
       <SlidePanel open={showLaunch}>


### PR DESCRIPTION
## Summary
- use a single arrow icon to toggle Caixa/Bancos info sidebar
- remove theme usage from main menu sidebar styles

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6850a7eb3648832f996278f2c2c50014